### PR TITLE
Enforce no important declarations.

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ module.exports = {
     ],
     rules: {
       'at-rule-no-unknown': null,
+      'declaration-no-important': true,
       indentation: 4,
       'scss/at-rule-no-unknown': true,
       'selector-list-comma-newline-after': 'always',


### PR DESCRIPTION
Although we all try to avoid them, we don't have anything in best practices to say we can't use important declarations. I'm suggesting we enable this rule in the hopes that adding a `stylelint-disable-next-line declaration-no-important` comment will also remind people to document why they've had to use it.